### PR TITLE
Fix incorrect routing mapping for multiple steps.

### DIFF
--- a/qgym/envs/routing/routing_state.py
+++ b/qgym/envs/routing/routing_state.py
@@ -208,8 +208,12 @@ class RoutingState(State[Dict[str, NDArray[np.int_]], int]):
             return self
 
         qubit1, qubit2 = self.edges[action]
+
+        # Get the logical qubits from the mapping
+        logical_qubit1, logical_qubit2 = (np.flatnonzero(self.mapping == p)[0] for p in (qubit1, qubit2))
+
         self._place_swap_gate(qubit1, qubit2)
-        self._update_mapping(qubit1, qubit2)
+        self._update_mapping(logical_qubit1, logical_qubit2)
 
         return self
 

--- a/tests/envs/routing/test_routing_env.py
+++ b/tests/envs/routing/test_routing_env.py
@@ -7,25 +7,42 @@ from stable_baselines3.common.env_checker import check_env
 from qgym.envs.routing.routing import Routing
 
 
-@pytest.mark.parametrize(
-    "kwargs",
-    [
-        {"connection_graph": (2, 2)},
-        {"connection_graph": (2, 2), "observe_legal_surpasses": False},
-        {"connection_graph": (2, 2), "observe_connection_graph": False},
-        {
-            "connection_graph": (2, 2),
-            "observe_legal_surpasses": False,
-            "observe_connection_graph": False,
-        },
-    ],
-)
 class TestEnvironment:
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"connection_graph": (2, 2)},
+            {"connection_graph": (2, 2), "observe_legal_surpasses": False},
+            {"connection_graph": (2, 2), "observe_connection_graph": False},
+            {
+                "connection_graph": (2, 2),
+                "observe_legal_surpasses": False,
+                "observe_connection_graph": False,
+            },
+        ],
+    )
     def test_validity(self, kwargs: dict[str, tuple[int, int] | bool]) -> None:
         env = Routing(**kwargs)  # type: ignore[arg-type]
         check_env(env, warn=True)  # todo: maybe switch this to the gym env checker
 
-    def test_step(self, kwargs: dict[str, tuple[int, int] | bool]) -> None:
-        env = Routing(**kwargs)  # type: ignore[arg-type]
+    def test_step(self) -> None:
+        env = Routing(connection_graph=[2, 2])  # type: ignore[arg-type]
         obs = env.step(0)[0]
         np.testing.assert_array_equal(obs["mapping"], [2, 1, 0, 3])
+
+    @pytest.mark.parametrize(
+        ("actions", "mapping"),
+        [
+            ([0, 1], [2, 0, 1]),  # swap(q0, q2), swap(q1, q2)
+            ([1, 0], [1, 2, 0]),  # swap(q1, q2), swap(q0, q2)
+        ]
+    )
+    def test_multiple_steps(self, actions,
+                            mapping) -> None:
+        env = Routing(connection_graph=[1, 3])
+
+        for action in actions:
+            obs = env.step(action)[0]
+
+        # noinspection PyUnboundLocalVariable
+        np.testing.assert_array_equal(obs["mapping"], mapping)


### PR DESCRIPTION
Fixes logical qubit indexing error in RoutingState class and add multiple steps test in test_routing_env.py

Adjusted the logical qubit indexing error in the RoutingState class to correctly update the mapping after placing a swap gate between qubit pairs. Additionally, added a new test in test_routing_env.py to verify multiple steps of qubit swaps correctly update the mapping.