### PR TITLE
Update numpy version requirement to only allow versions below 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ keywords =[
 dependencies = [
     "gymnasium>=0.28.1",
     "networkx[default]>=2.6.3",
-    "numpy>=1.21.6",
+    "numpy>=1.21.6,<2",
     "pygame",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
- Updated numpy version requirement to allow versions below 2 on top of starting from 1.21.6.